### PR TITLE
Add Number Param to call ended

### DIFF
--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -290,7 +290,7 @@ class BareSIP(Thread):
     def handle_call_established(self):
         LOG.info("Call established")
 
-    def handle_call_ended(self, reason, number):
+    def handle_call_ended(self, reason, number=None):
         LOG.info("Call ended")
         LOG.debug(f"Number: {number} , Reason: {reason}")
 

--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -290,9 +290,9 @@ class BareSIP(Thread):
     def handle_call_established(self):
         LOG.info("Call established")
 
-    def handle_call_ended(self, reason):
+    def handle_call_ended(self, reason, number):
         LOG.info("Call ended")
-        LOG.debug("Reason: " + reason)
+        LOG.debug(f"Number: {number} , Reason: {reaon}")
 
     def _handle_no_accounts(self):
         LOG.debug("No accounts setup")
@@ -402,10 +402,11 @@ class BareSIP(Thread):
                         self.handle_mic_unmuted()
                     elif "session closed:" in out:
                         reason = out.split("session closed:")[1].strip()
+                        number = out.split(": session closed:")[0].strip()
                         status = "DISCONNECTED"
                         self.handle_call_status(status)
                         self._call_status = status
-                        self.handle_call_ended(reason)
+                        self.handle_call_ended(reason, number)
                         self.mic_muted = False
                     elif "(no active calls)" in out:
                         status = "DISCONNECTED"

--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -292,7 +292,7 @@ class BareSIP(Thread):
 
     def handle_call_ended(self, reason, number):
         LOG.info("Call ended")
-        LOG.debug(f"Number: {number} , Reason: {reaon}")
+        LOG.debug(f"Number: {number} , Reason: {reason}")
 
     def _handle_no_accounts(self):
         LOG.debug("No accounts setup")


### PR DESCRIPTION
When you use a [conference call ](https://github.com/baresip/baresip/wiki/Conference-Call) you currently have no way of knowing who left the call.
This pr aims to change that, providing the number of the caller who left as a param to `handle_call_ended`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced call termination logging now displays more detailed information, including call-specific identifiers alongside closure reasons, for improved insights during session end events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->